### PR TITLE
Adding shell snippet to restart all -rw-neo4j and public- services

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run \
 etcdctl set /ft/config/neo4j/read_write_url http://upp-pre-prod-uk-data-write-alb-up.ft.com/db/data/
 etcdctl set /ft/config/neo4j/read_only_url http://upp-pre-prod-uk-data-read-alb-up.ft.com/db/data/
 ```
-- The `*-rw-neo4j` and `public-*` services need to be restarted to pick up the new URLs. Run the following shell snippet:
+- The `*-rw-neo4j` and `public-*` services need to be restarted to pick up the new URLs. Run the following shell snippet on the delivery cluster:
 ```
 for service in `fleetctl list-units | grep -e -rw-neo4j@ -e public- | grep -v sidekick | cut -f 1` ; do
     echo "Restarting ${service}"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ docker run \
 etcdctl set /ft/config/neo4j/read_write_url http://upp-pre-prod-uk-data-write-alb-up.ft.com/db/data/
 etcdctl set /ft/config/neo4j/read_only_url http://upp-pre-prod-uk-data-read-alb-up.ft.com/db/data/
 ```
-
+- The `*-rw-neo4j` and `public-*` services need to be restarted to pick up the new URLs. Run the following shell snippet:
+```
+for service in `fleetctl list-units | grep -e -rw-neo4j@ -e public- | grep -v sidekick | cut -f 1` ; do
+    echo "Restarting ${service}"
+    fleetctl ssh ${service} sudo systemctl restart ${service}
+done
+```
 
 ## Decommisioning a cluster
 - Export the required environment variables.


### PR DESCRIPTION
Needs to be run on delivery cluster when attaching or updating a neo4j cluster.