### PR TITLE
Increase write alb timeout to 120s

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -107,11 +107,15 @@ Before running the script you must set the following environment variables.
 export ENVIRONMENT_TAG="unique-env-name"
 export AWS_ACCESS_KEY_ID="key"
 export AWS_SECRET_ACCESS_KEY="secret"
+export AWS_DEFAULT_REGION="eu-west-1|us-east-1"
 export SERVICES_DEFINITION_ROOT_URI="https://raw.githubusercontent.com/Financial-Times/up-neo4j-service-files/master/"
 export SPLUNK_HEC_TOKEN="splunk-token"
 export SPLUNK_HEC_URL="https://http-inputs-financialtimes.splunkcloud.com/services/collector/event"
 export KONSTRUCTOR_API_KEY="konstructor-key"
 export NEO_EXTRA_CONF_URL="https://raw.githubusercontent.com/Financial-Times/up-neo4j-service-files/master/neo4j-extra-conf.sh"
+export TOKEN_URL=$(curl -s https://discovery.etcd.io/new?size=3)
+export ENVIRONMENT_TYPE="d|t|p"
+
 ```
 
 Once environment variables are set start provisioning with the following command.

--- a/cloudformation/neo4jhacluster.yaml
+++ b/cloudformation/neo4jhacluster.yaml
@@ -42,7 +42,7 @@ Metadata:
 
 
 Parameters:
-  
+
   # Defines the VPC and Subnets that are to be used in provisioning.  Defaults to the eu-west-1 vpc/subnets.
   VPC:
     Description: This is the VPC the stack will be deployed inside.
@@ -406,7 +406,7 @@ Resources:
               "          ExecStart=/bin/sh -c \"curl -sSL --retry 5 --retry-delay 2 -o /tmp/deployer.service https://raw.githubusercontent.com/Financial-Times/coco-fleet-deployer/master/deployer.service && fleetctl start /tmp/deployer.service\"\n",
               "          ExecStartPost=/usr/bin/touch /var/lib/format-done\n",
               "\n",
-              "write_files:\n",           
+              "write_files:\n",
               "  - path: /etc/sysctl.d/50-disable-ipv6.conf\n",
               "    content: |\n",
               "      net.ipv6.conf.all.disable_ipv6=1\n",
@@ -540,6 +540,9 @@ Resources:
     Properties:
       Name: !Sub ${AWS::StackName}-write-alb
       Scheme: internal
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: 120
       SecurityGroups:
         - !Ref CoreOSSecurityGroup
         - !Ref Neo4JSecurityGroup


### PR DESCRIPTION
Increase write ALB ide timeout from default 60s to 120s to prevent rw-neo4j health check flapping.